### PR TITLE
PS-7144 : incorrect number of doublewrite files created if innodb_buffer_pool_size > 1G

### DIFF
--- a/mysql-test/suite/innodb/r/dblwr_file_count.result
+++ b/mysql-test/suite/innodb/r/dblwr_file_count.result
@@ -1,0 +1,3 @@
+#
+# PS-7144 : incorrect number of doublewrite files created if innodb_buffer_pool_size > 1G
+#

--- a/mysql-test/suite/innodb/t/dblwr_file_count-master.opt
+++ b/mysql-test/suite/innodb/t/dblwr_file_count-master.opt
@@ -1,0 +1,1 @@
+--innodb_buffer_pool_size=1G

--- a/mysql-test/suite/innodb/t/dblwr_file_count.test
+++ b/mysql-test/suite/innodb/t/dblwr_file_count.test
@@ -1,0 +1,22 @@
+# Test needs 1G min buffer pool size
+--source include/big_test.inc
+
+--echo #
+--echo # PS-7144 : incorrect number of doublewrite files created if innodb_buffer_pool_size > 1G
+--echo #
+
+--let $MYSQLD_DATADIR=`SELECT @@datadir`
+--let $PAGE_SIZE=`SELECT @@innodb_page_size`
+
+--let $max = `SELECT @@innodb_buffer_pool_instances * 2`
+--let $i = 0
+
+while ($i < $max) {
+--let $part1=$MYSQLD_DATADIR/#ib_$PAGE_SIZE
+--let $part2=_$i.dblwr
+--let $file= $part1$part2
+
+--file_exists $file
+
+--inc $i
+}

--- a/storage/innobase/buf/buf0dblwr.cc
+++ b/storage/innobase/buf/buf0dblwr.cc
@@ -1746,7 +1746,9 @@ dberr_t dblwr::open(bool create_new_db) noexcept {
   uint32_t segments_per_file{};
 
   if (dblwr::n_files == 0) {
-    dblwr::n_files = 2;
+    dblwr::n_files = std::max(2UL, srv_buf_pool_instances * 2);
+  } else if (dblwr::n_files > srv_buf_pool_instances * 2) {
+    dblwr::n_files = srv_buf_pool_instances * 2;
   }
 
   ib::info(ER_IB_MSG_DBLWR_1324)
@@ -1759,7 +1761,7 @@ dberr_t dblwr::open(bool create_new_db) noexcept {
   ib::info(ER_IB_MSG_DBLWR_1323)
       << "Double write buffer pages per instance: " << dblwr::n_pages;
 
-  if (Double_write::s_n_instances < dblwr::n_files) {
+  if (Double_write::s_n_instances <= dblwr::n_files) {
     segments_per_file = 1;
     Double_write::s_files.resize(Double_write::s_n_instances);
   } else {


### PR DESCRIPTION
    Problem:
    -------
    According to documentation, default value of innodb_doublewrite_files is
    innodb_buffer_pool_instances * 2
    
    But when you start InnoDB with buffer pool size > 1G (the number of instances
    is 8), it still creates 2 files only. Expected files is 16 (8*2)
    
    Fix:
    ----
    If buffer pool size is >= 1G and the explicit number of dblwr files not
    specified, create 2*innodb_buffer_pool_instances files
